### PR TITLE
[fix] GitHub and Commenter should be per-request, not singletons

### DIFF
--- a/lib/plugins/jira/index.js
+++ b/lib/plugins/jira/index.js
@@ -32,10 +32,13 @@ class JiraPlugin {
    * @public
    * @param {Object} data PR webhook data
    * @param {Object} config Configuration for plugin
+   * @param {Object} apis A set of APIs needed to process the request
+   * @param {Commenter} apis.commenter Commenter object for aggregating comments to post
+   * @param {GitHubClient} apis.github A GitHubClient instance for this request
    * @param {Function} done Continuation callback
    * @returns {Undefined} Nothing of significance
    */
-  processRequest(data, config, done) { // eslint-disable-line max-statements
+  processRequest(data, config, apis, done) { // eslint-disable-line max-statements
     const isEdit = data.action === 'edited';
     let oldTitle = null;
 
@@ -65,7 +68,7 @@ class JiraPlugin {
       return void done();
     }
 
-    this.findTicketsAndPost(ticketIds, done);
+    this.findTicketsAndPost(ticketIds, apis.commenter, done);
   }
 
   /**
@@ -74,9 +77,10 @@ class JiraPlugin {
    * @memberof JiraPlugin
    * @private
    * @param {String[]} ticketIds A list of ticket IDs
+   * @param {Commenter} commenter Commenter object for aggregating comments to post
    * @param {Function} done Continuation callback
    */
-  findTicketsAndPost(ticketIds, done) {
+  findTicketsAndPost(ticketIds, commenter, done) {
     const jql = `id in ('${ticketIds.join("', '")}')`;
 
     request.post(`${this.jiraConfig.protocol}://${this.jiraConfig.host}/rest/api/2/search`, {
@@ -106,7 +110,7 @@ class JiraPlugin {
 
       // call some API to post the comment on the PR
       const comment = `I found the following Jira ticket(s) referenced in this PR:\n${ticketList}`;
-      this.app.commenter.addComment(comment, Commenter.priority.Low);
+      commenter.addComment(comment, Commenter.priority.Low);
       done();
     });
   }

--- a/lib/plugins/required-file/index.js
+++ b/lib/plugins/required-file/index.js
@@ -30,16 +30,19 @@ class RequiredFilePlugin {
    * @param {Object} data PR webhook data
    * @param {Object} config Configuration for this plugin
    * @param {String[]} config.files File paths to require in the PR
+   * @param {Object} apis A set of APIs needed to process the request
+   * @param {Commenter} apis.commenter Commenter object for aggregating comments to post
+   * @param {GitHubClient} apis.github A GitHubClient instance for this request
    * @param {Function} done Continuation callback
    * @returns {Undefined} Nothing of significance
    */
-  processRequest(data, config, done) {
+  processRequest(data, config, apis, done) {
     const files = config && config.files;
     if (!files) {
       return done(new Error('Missing `files` field in plugin config'));
     }
 
-    async.each(files, this.checkFile.bind(this, data), done);
+    async.each(files, this.checkFile.bind(this, data, apis), done);
   }
 
   /**
@@ -53,18 +56,21 @@ class RequiredFilePlugin {
    * @memberof RequiredFilePlugin
    * @private
    * @param {Object} data PR webhook data
+   * @param {Object} apis A set of APIs needed to process the request
+   * @param {Commenter} apis.commenter Commenter object for aggregating comments to post
+   * @param {GitHubClient} apis.github A GitHubClient instance for this request
    * @param {String|RequiredFile} file The file object, or path to check, relative to the root of the repo
    * @param {Function} done Continuation callback
    * @returns {Undefined} Nothing of significance
    */
-  checkFile(data, file, done) {
+  checkFile(data, apis, file, done) {
     const filePath = typeof file === 'string' ? file : (file && file.path);
     if (!filePath) {
       return done(new Error('No file path specified for required file.'));
     }
     const message = file.message ||
       `You're missing a change to ${filePath}, which is a requirement for changes to this repo.`;
-    this.app.github.checkIfFileExists(data.repository.full_name, filePath, (checkFileExistsErr, exists) => {
+    apis.github.checkIfFileExists(data.repository.full_name, filePath, (checkFileExistsErr, exists) => {
       if (checkFileExistsErr) return done(checkFileExistsErr);
 
       if (!exists) {
@@ -72,13 +78,13 @@ class RequiredFilePlugin {
         return done();
       }
 
-      this.app.github.getFilesInPullRequest(data.repository.full_name, data.pull_request.number, (getPRFilesErr, files) => {
+      apis.github.getFilesInPullRequest(data.repository.full_name, data.pull_request.number, (getPRFilesErr, files) => {
         if (getPRFilesErr) return done(getPRFilesErr);
 
         if (!files.some(f => {
           return f.filename === filePath;
         })) {
-          this.app.commenter.addComment(message, Commenter.priority.High);
+          apis.commenter.addComment(message, Commenter.priority.High);
         }
 
         return void done();

--- a/lib/plugins/reviewers/index.js
+++ b/lib/plugins/reviewers/index.js
@@ -38,15 +38,18 @@ class ReviewerPlugin {
    *  package.json
    * @param {Number} [config.howMany] Number of reviewers to choose from the set of contributors and maintainers,
    *  defaults to choosing all of the possible reviewers
+   * @param {Object} apis A set of APIs needed to process the request
+   * @param {Commenter} apis.commenter Commenter object for aggregating comments to post
+   * @param {GitHubClient} apis.github A GitHubClient instance for this request
    * @param {Function} done Continuation callback
    */
-  processRequest(data, config, done) {
+  processRequest(data, config, apis, done) {
     config = config || {};
     const commentFormat = config.commentFormat || this.defaultCommentFormat;
     if (config.reviewers) {
-      this.requestReviews(data, config.reviewers, config.howMany, commentFormat, done);
+      this.requestReviews(data, config.reviewers, config.howMany, commentFormat, apis, done);
     } else {
-      this.getPackageJson(data.repository, (packageJsonErr, packageInfo) => {
+      this.getPackageJson(data.repository, apis, (packageJsonErr, packageInfo) => {
         if (packageJsonErr) return done(packageJsonErr);
         if (!packageInfo) {
           // No package.json, nothing to do
@@ -58,6 +61,7 @@ class ReviewerPlugin {
           reviewers,
           config.howMany,
           commentFormat,
+          apis,
           done);
       });
     }
@@ -120,16 +124,19 @@ class ReviewerPlugin {
    * @param {Number} [howMany] How many reviewers to select, default is all
    * @param {String} [commentFormat] An optional comment format string to use when posting a comment about
    *  the review request
+   * @param {Object} apis A set of APIs needed to process the request
+   * @param {Commenter} apis.commenter Commenter object for aggregating comments to post
+   * @param {GitHubClient} apis.github A GitHubClient instance for this request
    * @param {Function} done Continuation callback
    * @returns {Undefined} Nothing of significance
    */
-  requestReviews(data, reviewers, howMany, commentFormat, done) { // eslint-disable-line max-params
+  requestReviews(data, reviewers, howMany, commentFormat, apis, done) { // eslint-disable-line max-params
     if (!reviewers) {
       // No users to work with, nothing to do
       return void done();
     }
 
-    this.getUsersFromReviewersList(reviewers, data.pull_request, (err, userList) => {
+    this.getUsersFromReviewersList(reviewers, data.pull_request, apis, (err, userList) => {
       if (err) return done(err);
       if (!userList || userList.length === 0) {
         // No reviewers, nothing to do
@@ -144,13 +151,13 @@ class ReviewerPlugin {
 
       if (commentFormat) {
         const githubUsernames = usersToRequest.sort().map(username => `@${username}`).join(', ');
-        this.app.commenter.addComment(
+        apis.commenter.addComment(
           commentFormat.replace('%s', githubUsernames),
           Commenter.priority.High
         );
       }
 
-      this.app.github.requestReviewers(
+      apis.github.requestReviewers(
         data.repository.full_name,
         data.pull_request.number,
         usersToRequest,
@@ -165,10 +172,12 @@ class ReviewerPlugin {
    * @memberof ReviewerPlugin
    * @private
    * @param {Object} repoInfo Repository info
+   * @param {Object} apis A set of APIs needed to process the request
+   * @param {GitHubClient} apis.github A GitHubClient instance for this request
    * @param {Function} done Continuation callback
    */
-  getPackageJson(repoInfo, done) {
-    this.app.github.getFileContents(repoInfo.full_name, {
+  getPackageJson(repoInfo, apis, done) {
+    apis.github.getFileContents(repoInfo.full_name, {
       path: 'package.json'
     }, (getRcErr, pkg) => {
       if (getRcErr) {
@@ -178,7 +187,7 @@ class ReviewerPlugin {
         return done(getRcErr);
       }
 
-      this.app.github.parsePackageJson(pkg, done);
+      apis.github.parsePackageJson(pkg, done);
     });
   }
 
@@ -189,10 +198,12 @@ class ReviewerPlugin {
    * @private
    * @param {String[]} reviewers List of reviewers, often in the format `Joe Schmoe <jschmoe@domain.com>`
    * @param {Object} prInfo PR information
+   * @param {Object} apis A set of APIs needed to process the request
+   * @param {GitHubClient} apis.github A GitHubClient instance for this request
    * @param {Function} done Continuation callback
    * @returns {Undefined} Nothing of significance
    */
-  getUsersFromReviewersList(reviewers, prInfo, done) {
+  getUsersFromReviewersList(reviewers, prInfo, apis, done) {
     if (!reviewers || !reviewers.length) return done();
 
     const maybeUsers = Array.from(new Set(reviewers.map(r => {
@@ -214,7 +225,7 @@ class ReviewerPlugin {
     })));
 
     async.reduce(maybeUsers, [], (memo, user, next) => {
-      this.app.github.userExists(user, (userExistsErr, exists) => {
+      apis.github.userExists(user, (userExistsErr, exists) => {
         if (userExistsErr) return next(userExistsErr);
         next(null, exists ? memo.concat([user]) : memo);
       });

--- a/lib/preboots/commenter.js
+++ b/lib/preboots/commenter.js
@@ -1,8 +1,0 @@
-const Commenter = require('../commenter');
-
-function CommenterPreboot(app, opts, callback) {
-  app.commenter = new Commenter();
-  callback();
-}
-
-module.exports = CommenterPreboot;

--- a/lib/preboots/github.js
+++ b/lib/preboots/github.js
@@ -1,9 +1,0 @@
-const GitHubClient = require('../github');
-
-function GitHubPreboot(app, opts, callback) {
-  const config = app.config.get('github');
-  app.github = new GitHubClient(config);
-  callback();
-}
-
-module.exports = GitHubPreboot;

--- a/lib/preboots/index.js
+++ b/lib/preboots/index.js
@@ -26,8 +26,6 @@ function Preboots(app, opts, callback) {
     Prism.highlight(options.fn(), Prism.languages.json, 'json')));
   app.engine('hbs', hbs.__express);
 
-  app.preboot(require('./github'));
-  app.preboot(require('./commenter'));
   app.preboot(require('./processor'));
   app.preboot(require('./plugins'));
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,4 +1,5 @@
 const async = require('async');
+const Commenter = require('./commenter');
 
 /**
  * Processor for incoming webhook requests
@@ -19,10 +20,11 @@ class Processor {
    * @memberof Processor
    * @public
    * @param {HTTPRequest} req Request object from Slay
+   * @param {GitHubClient} github The GitHubClient instance for this request
    * @param {Function} done Continuation callback
    * @returns {Undefined} Nothing of significance
    */
-  processRequest(req, done) {
+  processRequest(req, github, done) {
     const eventType = req.headers['x-github-event'];
     if (eventType !== 'pull_request') {
       // Not a PR, nothing to do
@@ -40,7 +42,7 @@ class Processor {
 
     this.app.log.info('Processing PR', { repository: data.repository.full_name, number: data.number, requestId });
 
-    this.getRepoConfig(data.repository, (getRepoConfigErr, config) => {
+    this.getRepoConfig(data.repository, github, (getRepoConfigErr, config) => {
       if (getRepoConfigErr) {
         this.app.log.error('Error getting repository config', { error: getRepoConfigErr, requestId });
         return done(getRepoConfigErr);
@@ -52,6 +54,11 @@ class Processor {
           { repository: data.repository.full_name, requestId });
         return done();
       }
+
+      const apis = {
+        commenter: new Commenter(),
+        github
+      };
 
       async.each(config.plugins, (pluginConfig, next) => {
         const pluginName = typeof pluginConfig === 'string' ? pluginConfig : pluginConfig.plugin;
@@ -66,7 +73,7 @@ class Processor {
           return next();
         }
 
-        plugin.processRequest(data, pluginConfig.config || {}, pluginProcessRequestErr => {
+        plugin.processRequest(data, pluginConfig.config || {}, apis, pluginProcessRequestErr => {
           if (pluginProcessRequestErr) {
             this.app.log.error('Error running plugin',
               { error: pluginProcessRequestErr, repository: data.repository.full_name, plugin: pluginName, requestId });
@@ -80,9 +87,9 @@ class Processor {
         this.app.log.info('Finished processing PR',
           { repository: data.repository.full_name, number: data.number, requestId });
 
-        const comment = this.app.commenter.flushToString();
+        const comment = apis.commenter.flushToString();
         if (comment) {
-          this.app.github.createIssueComment(data.repository.full_name, data.pull_request.number, comment, done);
+          github.createIssueComment(data.repository.full_name, data.pull_request.number, comment, done);
         } else {
           return done();
         }
@@ -96,10 +103,11 @@ class Processor {
    * @memberof Processor
    * @private
    * @param {Object} repoInfo Information about the target repo retrieved from the webhook payload
+   * @param {GitHubClient} github The GitHubClient instance for this request
    * @param {Function} done Continuation callback
    */
-  getRepoConfig(repoInfo, done) {
-    this.app.github.getFileContents(repoInfo.full_name, {
+  getRepoConfig(repoInfo, github, done) {
+    github.getFileContents(repoInfo.full_name, {
       path: '.pullierc'
     }, (getRcErr, pkg) => {
       if (getRcErr) {
@@ -109,7 +117,7 @@ class Processor {
         return done(getRcErr);
       }
 
-      this.app.github.parsePackageJson(pkg, done);
+      github.parsePackageJson(pkg, done);
     });
   }
 }

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,6 +1,7 @@
 const { normalizeError } = require('../utils');
 const resolveCwd = require('resolve-cwd');
 const packageJson = require('../../package.json');
+const GitHubClient = require('../github');
 
 /*
  * Setup the ordering for all of our routing in
@@ -37,17 +38,18 @@ function Routes(app, opts, callback) {
         });
         return next();
       }
-      app.github.login(req.body.installation.id, loginErr => {
+      const github = new GitHubClient(config);
+      github.login(req.body.installation.id, loginErr => {
         if (loginErr) {
-          app.github.logout();
+          github.logout();
           res.status(403).json({
             error: loginErr.toString()
           });
           return next();
         }
 
-        app.processor.processRequest(req, processErr => {
-          app.github.logout();
+        app.processor.processRequest(req, github, processErr => {
+          github.logout();
           if (processErr) {
             const status = processErr.status || 500;
             res.status(status).json({

--- a/test/unit/plugins/jira.test.js
+++ b/test/unit/plugins/jira.test.js
@@ -14,7 +14,9 @@ const mockApp = {
       username: 'username',
       password: 'password'
     })
-  },
+  }
+};
+const mockApis = {
   commenter: {
     addComment: addCommentStub
   }
@@ -42,7 +44,7 @@ describe('JiraPlugin', () => {
 
     it('is a function', () => {
       assume(jiraPlugin.processRequest).is.a('function');
-      assume(jiraPlugin.processRequest).has.length(3);
+      assume(jiraPlugin.processRequest).has.length(4);
     });
 
     it(`bails out if the PR action is an edit and the title hasn't changed`, (done) => {
@@ -56,7 +58,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: 'title'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(requestPostStub).has.not.been.called();
         done();
@@ -74,7 +76,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: 'title'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(requestPostStub).has.not.been.called();
         done();
@@ -87,7 +89,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: 'title with no Jira tickets'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(requestPostStub).has.not.been.called();
         done();
@@ -102,7 +104,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: '[AB-1234] title with 1 Jira ticket'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.truthy();
         assume(err).equals(mockError);
         assume(requestPostStub).has.been.called();
@@ -117,7 +119,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: '[AB-1234] title with 1 Jira ticket'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.truthy();
         assume(err.message).contains('Status code: unknown');
         assume(requestPostStub).has.been.called();
@@ -134,7 +136,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: '[AB-1234] title with 1 Jira ticket'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.truthy();
         assume(err.message).contains('Status code: 404');
         assume(requestPostStub).has.been.called();
@@ -160,7 +162,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: '[AB-1234] title with 1 Jira ticket'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(requestPostStub).has.been.calledWithMatch(
           sinon.match.string,
@@ -196,7 +198,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: '[AB-1234] title with 2 Jira tickets [FOO-5678]'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(requestPostStub).has.been.calledWithMatch(
           sinon.match.string,
@@ -233,7 +235,7 @@ describe('JiraPlugin', () => {
         pull_request: {
           title: 'AB-1234 title with 2 Jira tickets FOO-5678'
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(requestPostStub).has.been.calledWithMatch(
           sinon.match.string,
@@ -257,7 +259,7 @@ describe('JiraPlugin', () => {
             from: '[AB-1234] title that has changed with 2 Jira tickets [FOO-5678]'
           }
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(addCommentStub).has.not.been.called();
         done();
@@ -293,7 +295,7 @@ describe('JiraPlugin', () => {
             from: '[AB-3456] title with 2 Jira tickets [FOO-7980]'
           }
         }
-      }, null, (err) => {
+      }, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(requestPostStub).has.been.calledWithMatch(
           sinon.match.string,

--- a/test/unit/plugins/reviewers.test.js
+++ b/test/unit/plugins/reviewers.test.js
@@ -13,17 +13,19 @@ const parsePackageJsonStub = sandbox.stub().callsArgAsync(1);
 const userExistsStub = sandbox.stub().callsArgAsync(1);
 const addCommentStub = sandbox.stub();
 const mockApp = {
+  config: {
+    get: sinon.stub()
+  }
+};
+const mockApis = {
+  commenter: {
+    addComment: addCommentStub
+  },
   github: {
     requestReviewers: requestReviewersStub,
     getFileContents: getFileContentsStub,
     parsePackageJson: parsePackageJsonStub,
     userExists: userExistsStub
-  },
-  commenter: {
-    addComment: addCommentStub
-  },
-  config: {
-    get: sinon.stub()
   }
 };
 
@@ -59,13 +61,13 @@ describe('ReviewersPlugin', () => {
   describe('.processRequest', () => {
     it('is a function', () => {
       assume(reviewersPlugin.processRequest).is.a('function');
-      assume(reviewersPlugin.processRequest).has.length(3);
+      assume(reviewersPlugin.processRequest).has.length(4);
     });
 
     it('bails out if getPackageJson returns an error', (done) => {
       const mockError = new Error('mock error');
-      const getPackageJsonStub = sandbox.stub(reviewersPlugin, 'getPackageJson').callsArgWithAsync(1, mockError);
-      reviewersPlugin.processRequest(mockData, null, (err) => {
+      const getPackageJsonStub = sandbox.stub(reviewersPlugin, 'getPackageJson').callsArgWithAsync(2, mockError);
+      reviewersPlugin.processRequest(mockData, null, mockApis, (err) => {
         assume(err).equals(mockError);
         getPackageJsonStub.restore();
         done();
@@ -73,10 +75,10 @@ describe('ReviewersPlugin', () => {
     });
 
     it('bails out if no package.json is found', (done) => {
-      const getPackageJsonStub = sandbox.stub(reviewersPlugin, 'getPackageJson').callsArgWithAsync(1, null, null);
+      const getPackageJsonStub = sandbox.stub(reviewersPlugin, 'getPackageJson').callsArgWithAsync(2, null, null);
       // eslint-disable-next-line id-length
       const getAllPossibleReviewersSpy = sandbox.spy(reviewersPlugin, 'getAllPossibleReviewers');
-      reviewersPlugin.processRequest(mockData, null, (err) => {
+      reviewersPlugin.processRequest(mockData, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(getAllPossibleReviewersSpy).has.not.been.called();
         getPackageJsonStub.restore();
@@ -88,14 +90,14 @@ describe('ReviewersPlugin', () => {
     it('properly passes package.json info to getAllPossibleReviewers and requestReviews', (done) =>  {
       const mockPackageInfo = {};
       const getPackageJsonStub = sandbox.stub(reviewersPlugin, 'getPackageJson')
-        .callsArgWithAsync(1, null, mockPackageInfo);
+        .callsArgWithAsync(2, null, mockPackageInfo);
       const mockReviewers = ['one', 'two'];
       // eslint-disable-next-line id-length
       const getAllPossibleReviewersStub = sandbox.stub(reviewersPlugin, 'getAllPossibleReviewers')
         .returns(mockReviewers);
       const requestReviewsStub = sandbox.stub(reviewersPlugin, 'requestReviews')
-        .callsArgAsync(4);
-      reviewersPlugin.processRequest(mockData, null, (err) => {
+        .callsArgAsync(5);
+      reviewersPlugin.processRequest(mockData, null, mockApis, (err) => {
         assume(err).is.falsey();
         assume(getAllPossibleReviewersStub).has.been.calledWithMatch(
           sinon.match.same(mockPackageInfo)
@@ -115,10 +117,10 @@ describe('ReviewersPlugin', () => {
       const getPackageJsonStub = sandbox.stub(reviewersPlugin, 'getPackageJson');
       const mockReviewers = ['one', 'two'];
       const requestReviewsStub = sandbox.stub(reviewersPlugin, 'requestReviews')
-        .callsArgAsync(4);
+        .callsArgAsync(5);
       reviewersPlugin.processRequest(mockData, {
         reviewers: mockReviewers
-      }, (err) => {
+      }, mockApis, (err) => {
         assume(err).is.falsey();
         assume(getPackageJsonStub).has.not.been.called();
         assume(requestReviewsStub).has.been.calledWithMatch(
@@ -209,7 +211,7 @@ describe('ReviewersPlugin', () => {
   describe('.requestReviews', () => {
     it('bails out if no reviewers are specified', (done) => {
       const getUsersFromReviewersListStub = sandbox.stub(reviewersPlugin, 'getUsersFromReviewersList');
-      reviewersPlugin.requestReviews({}, null, null, null, () => {
+      reviewersPlugin.requestReviews({}, null, null, null, null, () => {
         assume(getUsersFromReviewersListStub).has.not.been.called();
         getUsersFromReviewersListStub.restore();
         done();
@@ -218,8 +220,8 @@ describe('ReviewersPlugin', () => {
 
     it('bails out if getUsersFromReviewersList returns an error', (done) => {
       const getUsersFromReviewersListStub = sandbox.stub(reviewersPlugin, 'getUsersFromReviewersList')
-        .callsArgWithAsync(2, new Error('getUsersFromReviewersListError'));
-      reviewersPlugin.requestReviews({}, [], null, null, (err) => {
+        .callsArgWithAsync(3, new Error('getUsersFromReviewersListError'));
+      reviewersPlugin.requestReviews({}, [], null, null, null, (err) => {
         assume(getUsersFromReviewersListStub).has.been.called();
         assume(err).is.truthy();
         assume(err.message).equals('getUsersFromReviewersListError');
@@ -230,8 +232,8 @@ describe('ReviewersPlugin', () => {
 
     it('bails out if no users are found to request review from', (done) => {
       const getUsersFromReviewersListStub = sandbox.stub(reviewersPlugin, 'getUsersFromReviewersList')
-        .callsArgWithAsync(2, null, []);
-      reviewersPlugin.requestReviews({}, ['one'], null, null, () => {
+        .callsArgWithAsync(3, null, []);
+      reviewersPlugin.requestReviews({}, ['one'], null, null, null, () => {
         assume(getUsersFromReviewersListStub).has.been.called();
         assume(requestReviewersStub).has.not.been.called();
         getUsersFromReviewersListStub.restore();
@@ -246,12 +248,12 @@ describe('ReviewersPlugin', () => {
         'three'
       ];
       const getUsersFromReviewersListStub = sandbox.stub(reviewersPlugin, 'getUsersFromReviewersList')
-        .callsArgWithAsync(2, null, candidateReviewers);
+        .callsArgWithAsync(3, null, candidateReviewers);
       const howManyRequested = 2;
       reviewersPlugin.requestReviews({
         repository: {},
         pull_request: {}
-      }, candidateReviewers, howManyRequested, null, () => {
+      }, candidateReviewers, howManyRequested, null, mockApis, () => {
         assume(getUsersFromReviewersListStub).has.been.called();
         assume(requestReviewersStub).has.been.calledWithMatch(
           sinon.match.any,
@@ -275,12 +277,12 @@ describe('ReviewersPlugin', () => {
         'three'
       ];
       const getUsersFromReviewersListStub = sandbox.stub(reviewersPlugin, 'getUsersFromReviewersList')
-        .callsArgWithAsync(2, null, candidateReviewers);
+        .callsArgWithAsync(3, null, candidateReviewers);
       const howManyRequested = 4;
       reviewersPlugin.requestReviews({
         repository: {},
         pull_request: {}
-      }, candidateReviewers, howManyRequested, null, () => {
+      }, candidateReviewers, howManyRequested, null, mockApis, () => {
         assume(getUsersFromReviewersListStub).has.been.called();
         assume(requestReviewersStub).has.been.calledWithMatch(
           sinon.match.any,
@@ -302,11 +304,11 @@ describe('ReviewersPlugin', () => {
         'three'
       ];
       const getUsersFromReviewersListStub = sandbox.stub(reviewersPlugin, 'getUsersFromReviewersList')
-        .callsArgWithAsync(2, null, candidateReviewers);
+        .callsArgWithAsync(3, null, candidateReviewers);
       reviewersPlugin.requestReviews({
         repository: {},
         pull_request: {}
-      }, candidateReviewers, null, 'Some comment %s', () => {
+      }, candidateReviewers, null, 'Some comment %s', mockApis, () => {
         assume(getUsersFromReviewersListStub).has.been.called();
         assume(addCommentStub).has.been.calledWithMatch('@one, @three, @two', Commenter.priority.High);
         getUsersFromReviewersListStub.restore();
@@ -321,11 +323,11 @@ describe('ReviewersPlugin', () => {
         'three'
       ];
       const getUsersFromReviewersListStub = sandbox.stub(reviewersPlugin, 'getUsersFromReviewersList')
-        .callsArgWithAsync(2, null, candidateReviewers);
+        .callsArgWithAsync(3, null, candidateReviewers);
       reviewersPlugin.requestReviews({
         repository: {},
         pull_request: {}
-      }, candidateReviewers, null, null, () => {
+      }, candidateReviewers, null, null, mockApis, () => {
         assume(getUsersFromReviewersListStub).has.been.called();
         assume(requestReviewersStub).has.been.calledWithMatch(
           sinon.match.any,
@@ -344,14 +346,14 @@ describe('ReviewersPlugin', () => {
   describe('.getPackageJson', () => {
     it('is a function', () => {
       assume(reviewersPlugin.getPackageJson).is.a('function');
-      assume(reviewersPlugin.getPackageJson).has.length(2);
+      assume(reviewersPlugin.getPackageJson).has.length(3);
     });
 
     it('bails out when package.json is missing', (done) => {
       getFileContentsStub.callsArgWithAsync(2, {
         statusCode: 404
       });
-      reviewersPlugin.getPackageJson(mockData.repository, (err) => {
+      reviewersPlugin.getPackageJson(mockData.repository, mockApis, (err) => {
         assume(err).is.falsey();
         assume(parsePackageJsonStub).has.not.been.called();
         done();
@@ -361,7 +363,7 @@ describe('ReviewersPlugin', () => {
     it('bails out when an error is encountered attempting to fetch package.json', (done) => {
       const mockError = new Error('mock error');
       getFileContentsStub.callsArgWithAsync(2, mockError);
-      reviewersPlugin.getPackageJson(mockData.repository, (err) => {
+      reviewersPlugin.getPackageJson(mockData.repository, mockApis, (err) => {
         assume(err).equals(mockError);
         assume(parsePackageJsonStub).has.not.been.called();
         done();
@@ -371,7 +373,7 @@ describe('ReviewersPlugin', () => {
     it('hands off the packaged file to githulk for parsing', (done) => {
       const mockPkg = {};
       getFileContentsStub.callsArgWithAsync(2, null, mockPkg);
-      reviewersPlugin.getPackageJson(mockData.repository, (err) => {
+      reviewersPlugin.getPackageJson(mockData.repository, mockApis, (err) => {
         assume(err).is.falsey();
         assume(parsePackageJsonStub).has.been.calledWith(mockPkg);
         done();
@@ -382,11 +384,11 @@ describe('ReviewersPlugin', () => {
   describe('.getUsersFromReviewersList', () => {
     it('is a function', () => {
       assume(reviewersPlugin.getUsersFromReviewersList).is.a('function');
-      assume(reviewersPlugin.getUsersFromReviewersList).has.length(3);
+      assume(reviewersPlugin.getUsersFromReviewersList).has.length(4);
     });
 
     it('bails out when reviewers is falsey', (done) => {
-      reviewersPlugin.getUsersFromReviewersList(null, null, (err, users) => {
+      reviewersPlugin.getUsersFromReviewersList(null, null, null, (err, users) => {
         assume(err).is.falsey();
         assume(users).is.falsey();
         done();
@@ -394,7 +396,7 @@ describe('ReviewersPlugin', () => {
     });
 
     it('bails out when reviewers is empty', (done) => {
-      reviewersPlugin.getUsersFromReviewersList([], null, (err, users) => {
+      reviewersPlugin.getUsersFromReviewersList([], null, null, (err, users) => {
         assume(err).is.falsey();
         assume(users).is.falsey();
         done();
@@ -403,7 +405,7 @@ describe('ReviewersPlugin', () => {
 
     it('passes through an error when userExists fails', (done) => {
       userExistsStub.callsArgWithAsync(1, new Error('userExists error'));
-      reviewersPlugin.getUsersFromReviewersList(['one', 'two'], mockData.pull_request, err => {
+      reviewersPlugin.getUsersFromReviewersList(['one', 'two'], mockData.pull_request, mockApis, err => {
         assume(err).is.truthy();
         assume(err.message).equals('userExists error');
         done();
@@ -426,7 +428,7 @@ describe('ReviewersPlugin', () => {
           name: 'Billy ObjectNoEmailHeimer'
         },
         12345
-      ], mockData.pull_request, (err, users) => {
+      ], mockData.pull_request, mockApis, (err, users) => {
         assume(err).is.falsey();
         assume(users).eqls([
           'jschmoe',


### PR DESCRIPTION
This is one of those bugs that wasn't obvious until Pullie started getting some use outside of one team at GoDaddy. Since the whole request pipeline is done across several asynchronous calls, we cannot depend on singleton instances of the commenter nor the logged-in `GitHubClient` instance.

This change pulls those two objects out of the top-level `app` and makes them per-request.