### PR TITLE
[feat] Add `process` interceptor

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -40,67 +40,68 @@ class Processor {
       return done();
     }
 
-    this.app.log.info('Processing PR', { repository: data.repository.full_name, number: data.number, requestId });
+    const logData = { repository: data.repository.full_name, number: data.number, requestId };
+    this.app.perform('process', logData, doneProcessing => {
+      this.app.log.info('Processing PR', logData);
 
-    this.getRepoConfig(data.repository, github, (getRepoConfigErr, config) => {
-      if (getRepoConfigErr) {
-        this.app.log.error('Error getting repository config', { error: getRepoConfigErr, requestId });
-        return done(getRepoConfigErr);
-      }
-
-      if (!config || !Array.isArray(config.plugins) || config.plugins.length === 0) {
-        // No config specified for this repo, nothing to do
-        this.app.log.info('No config specified for repo, nothing to do',
-          { repository: data.repository.full_name, requestId });
-        return done();
-      }
-
-      const apis = {
-        commenter: new Commenter(),
-        github
-      };
-
-      async.each(config.plugins, (pluginConfig, next) => {
-        const pluginName = typeof pluginConfig === 'string' ? pluginConfig : pluginConfig.plugin;
-        const plugin = this.app.plugins[pluginName];
-        if (!plugin) {
-          this.app.log.error('Invalid plugin specified in config',
-            { repository: data.repository.full_name, plugin: pluginName, requestId });
-          return next(new Error(`Invalid config: no plugin named '${pluginName}' exists.`));
+      this.getRepoConfig(data.repository, github, (getRepoConfigErr, config) => {
+        if (getRepoConfigErr) {
+          this.app.log.error('Error getting repository config', { error: getRepoConfigErr, requestId });
+          return doneProcessing(getRepoConfigErr);
         }
 
-        if (data.action === 'edited' && !plugin.processesEdits) {
-          return next();
+        if (!config || !Array.isArray(config.plugins) || config.plugins.length === 0) {
+          // No config specified for this repo, nothing to do
+          this.app.log.info('No config specified for repo, nothing to do', logData);
+          return doneProcessing();
         }
 
-        plugin.processRequest(data, pluginConfig.config || {}, apis, pluginProcessRequestErr => {
-          if (pluginProcessRequestErr) {
-            this.app.log.error('Error running plugin',
-              {
-                error: pluginProcessRequestErr,
-                repository: data.repository.full_name,
-                number: data.number,
-                plugin: pluginName,
-                requestId
-              });
-            return next(pluginProcessRequestErr);
+        const apis = {
+          commenter: new Commenter(),
+          github
+        };
+
+        async.each(config.plugins, (pluginConfig, next) => {
+          const pluginName = typeof pluginConfig === 'string' ? pluginConfig : pluginConfig.plugin;
+          const plugin = this.app.plugins[pluginName];
+          if (!plugin) {
+            this.app.log.error('Invalid plugin specified in config',
+              { repository: data.repository.full_name, plugin: pluginName, requestId });
+            return next(new Error(`Invalid config: no plugin named '${pluginName}' exists.`));
           }
-          next();
+
+          if (data.action === 'edited' && !plugin.processesEdits) {
+            return next();
+          }
+
+          plugin.processRequest(data, pluginConfig.config || {}, apis, pluginProcessRequestErr => {
+            if (pluginProcessRequestErr) {
+              this.app.log.error('Error running plugin',
+                {
+                  error: pluginProcessRequestErr,
+                  repository: data.repository.full_name,
+                  number: data.number,
+                  plugin: pluginName,
+                  requestId
+                });
+              return next(pluginProcessRequestErr);
+            }
+            next();
+          });
+        }, eachErr => {
+          if (eachErr) return doneProcessing(eachErr);
+
+          this.app.log.info('Finished processing PR', logData);
+
+          const comment = apis.commenter.flushToString();
+          if (comment) {
+            github.createIssueComment(data.repository.full_name, data.pull_request.number, comment, doneProcessing);
+          } else {
+            return doneProcessing();
+          }
         });
-      }, eachErr => {
-        if (eachErr) return done(eachErr);
-
-        this.app.log.info('Finished processing PR',
-          { repository: data.repository.full_name, number: data.number, requestId });
-
-        const comment = apis.commenter.flushToString();
-        if (comment) {
-          github.createIssueComment(data.repository.full_name, data.pull_request.number, comment, done);
-        } else {
-          return done();
-        }
       });
-    });
+    }, done);
   }
 
   /**

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -16,6 +16,7 @@ function nockFile(scope, path, contents) {
 describe('Pullie (integration)', function () {
   let pullie;
   let baseUrl;
+  const requestsProcessed = [];
 
   before(function (done) {
     const github = nock('https://github.test.fake')
@@ -64,6 +65,12 @@ describe('Pullie (integration)', function () {
       baseUrl = base;
       pullie = server;
 
+      // Subscribe to `process` interceptor to test it
+      pullie.before('process', (data, next) => {
+        requestsProcessed.push(data);
+        next();
+      });
+
       done();
     });
   });
@@ -79,6 +86,7 @@ describe('Pullie (integration)', function () {
       assume(res).hasOwn('statusCode', 200);
       assume(body).hasOwn('status', 'ok');
       assume(nock.isDone()).is.true();
+      assume(requestsProcessed.find(req => req.repository === 'org/repo' && req.number === 165)).is.truthy();
 
       done();
     });

--- a/test/unit/processor.test.js
+++ b/test/unit/processor.test.js
@@ -39,6 +39,11 @@ describe('Processor', () => { // eslint-disable-line max-statements
     log: {
       info: sandbox.stub(),
       error: sandbox.stub()
+    },
+    perform: function () {
+      const workFn = arguments[arguments.length - 2];
+      const callback = arguments[arguments.length - 1];
+      workFn(callback);
     }
   };
   const mockGithub = {


### PR DESCRIPTION
This PR just wraps the existing PR processing logic in an [Understudy interceptor](https://github.com/bmeck/understudy#understudy) so that consumers of the pullie server (i.e. the wrapping application that handles deployment) can get notifications of PRs being processed and grab some data from them (like repo and PR number) for logging/APM.

The PR looks a little scary, but it's really just some indentation and wrapping existing code in 1 new function. Then some tests added to validate the new functionality.