### PR TITLE
Support for username suffixes.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,6 @@ JIRA_PASSWORD=
 
 # Optional message to greet your new contributors
 #WELCOME_MESSAGE="Hey there, thanks for contributing to the project!"
+
+# Optional variable if defined, appends a suffix to the username pulled out from the email address, before checking if the user is a collaborator in the repo.
+#GITHUB_USER_SUFFIX="someusernamesuffix"

--- a/plugins/reviewers/index.js
+++ b/plugins/reviewers/index.js
@@ -216,9 +216,7 @@ export default class ReviewerPlugin extends BasePlugin {
       }
       const matches = REVIEWER_REGEX.exec(testSubject);
       if (!matches) return testSubject;
-      return process.env.GITHUB_USER_SUFFIX
-        ? `${matches[1]}${process.env.GITHUB_USER_SUFFIX}`
-        : matches[1];
+      return `${matches[1]}${process.env.GITHUB_USER_SUFFIX || ''}`;
     }).filter(r => {
       if (!r) return false;
       return r !== context.payload.pull_request.user.login;

--- a/plugins/reviewers/index.js
+++ b/plugins/reviewers/index.js
@@ -216,7 +216,9 @@ export default class ReviewerPlugin extends BasePlugin {
       }
       const matches = REVIEWER_REGEX.exec(testSubject);
       if (!matches) return testSubject;
-      return matches[1];
+      return process.env.GITHUB_USER_SUFFIX
+        ? `${matches[1]}${process.env.GITHUB_USER_SUFFIX}`
+        : matches[1];
     }).filter(r => {
       if (!r) return false;
       return r !== context.payload.pull_request.user.login;


### PR DESCRIPTION
Setting up a new environment variable `GITHUB_USER_SUFFIX` would enable consumers to add reviewers with username suffixes.